### PR TITLE
Make grafsy windows compatible

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,4 +115,4 @@ jobs:
       - name: Test rpm
         if: ${{ contains(matrix.os, 'centos') }}
         run: |
-          yum -y install libacl; rpm -i grafsy-0.0.0.1*rpm
+          rpm -i grafsy-0.0.0.1*rpm

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
 
@@ -14,34 +14,34 @@ jobs:
     strategy:
       matrix:
         go:
-          - ^1.13
-          - ^1.14
+          - ^1.19
+          - ^1.20
     steps:
 
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v2
-      with:
-        go-version: ${{ matrix.go }}
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go }}
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
 
-    - name: Install dependencies
-      run: |
-        sudo apt-get install -y libacl1-dev
-        go get golang.org/x/lint/golint
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -y libacl1-dev
+          GO111MODULE=off go get golang.org/x/lint/golint
 
-    - name: Test
-      run: |
-        make test
-        golint ./...
+      - name: Test
+        run: |
+          make test
+          golint ./...
 
-    - name: Build and run version
-      run: |
-        make VERSION=testing-version clean build
-        ./build/grafsy -v
-        CGO_ENABLED=0 make GO_FLAGS='-tags noacl' VERSION=testing-version clean build
-        ./build/grafsy -v
+      - name: Build and run version
+        run: |
+          make VERSION=testing-version clean build
+          ./build/grafsy -v
+          CGO_ENABLED=0 make GO_FLAGS='-tags noacl' VERSION=testing-version clean build
+          ./build/grafsy -v
 
   build:
     name: Build packages

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,12 @@ build/$(NAME): $(NAME)/main.go
 build/$(NAME)-client: $(NAME)-client/main.go
 	$(GO_BUILD)
 
+build/$(NAME).exe: $(NAME)/main.go
+	GOOS=windows $(GO_BUILD)
+
+build/$(NAME)-client.exe: $(NAME)-client/main.go
+	GOOS=windows $(GO_BUILD)
+
 #########################################################
 # Prepare artifact directory and set outputs for upload #
 #########################################################

--- a/config.go
+++ b/config.go
@@ -2,15 +2,15 @@ package grafsy
 
 import (
 	"fmt"
-	"github.com/BurntSushi/toml"
-	"github.com/pkg/errors"
 	"log"
 	"net"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
-	"syscall"
+
+	"github.com/BurntSushi/toml"
+	"github.com/pkg/errors"
 )
 
 // ConfigPath is the default path to the configuration file
@@ -170,14 +170,12 @@ func (conf *Config) prepareEnvironment() error {
 		Check if directories for temporary files exist.
 		This is especially important when your metricDir is in /tmp.
 	*/
-	oldUmask := syscall.Umask(0)
 
 	if _, err := os.Stat(conf.MetricDir); os.IsNotExist(err) {
 		os.MkdirAll(conf.MetricDir, 0777|os.ModeSticky)
 	} else {
 		os.Chmod(conf.MetricDir, 0777|os.ModeSticky)
 	}
-	syscall.Umask(oldUmask)
 
 	/*
 		Unfortunately some people write to MetricDir with random permissions.

--- a/config_windows.go
+++ b/config_windows.go
@@ -1,0 +1,1 @@
+config_freebsd.go


### PR DESCRIPTION
It looks to me like `syscall.Umask` does nothing since we are setting the file permissions explicitly. And now `grafsy` is built for windows, yaaaay!