### PR TITLE
packaging: don't fail if systemd is not ready

### DIFF
--- a/packaging/prerm
+++ b/packaging/prerm
@@ -1,4 +1,9 @@
 #!/bin/sh
 
-systemctl disable grafsy.service
-systemctl stop grafsy.service
+if [ -x /bin/systemctl ] && [ -d /run/systemd/system ]; then
+  systemctl stop grafsy.service || true
+  systemctl disable grafsy.service || true
+else
+  echo "Systemd not detected, skipping service stop/disable."
+fi
+


### PR DESCRIPTION
We faced a small issue while upgrading the package in a non systemd-context (in chroot). I just made the prerm more tolerant now.

```
/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold -o APT::Get::Remove=No install grafsy' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
The following packages will be upgraded:
  grafsy
1 upgraded, 0 newly installed, 0 to remove and 113 not upgraded.
Need to get 0 B/4796 kB of archives.
After this operation, 1109 kB of additional disk space will be used.
(Reading database ... 54271 files and directories currently installed.)
Preparing to unpack .../grafsy_2.1.5.c14.gf4d3a0e_amd64.deb ...
Removed /etc/systemd/system/multi-user.target.wants/grafsy.service.
System has not been booted with systemd as init system (PID 1). Can't operate.
Failed to connect to bus: Host is down
dpkg: warning: old grafsy package pre-removal script subprocess returned error exit status 1
dpkg: trying script from the new package instead ...
System has not been booted with systemd as init system (PID 1). Can't operate.
Failed to connect to bus: Host is down
dpkg: error processing archive /var/cache/apt/archives/grafsy_2.1.5.c14.gf4d3a0e_amd64.deb (--unpack):
 new grafsy package pre-removal script subprocess returned error exit status 1
disabled

```